### PR TITLE
Fixed symlinks generated in create_gae_bundle for icons/client_resources

### DIFF
--- a/src/simian/util/create_gae_bundle.sh
+++ b/src/simian/util/create_gae_bundle.sh
@@ -20,8 +20,8 @@ touch $BUNDLE_ROOT/simian/__init__.py
 ln -s ../$SIMIAN_REL_PATH/auth $BUNDLE_ROOT/simian/auth
 ln -s ../$SIMIAN_REL_PATH/mac $BUNDLE_ROOT/simian/mac
 ln -s ../$SIMIAN_REL_PATH/settings.py $BUNDLE_ROOT/simian/settings.py
-ln -s ../$SIMIAN_ROOT/gae_resources/icons $BUNDLE_ROOT/icons
-ln -s ../$SIMIAN_ROOT/gae_resources/client_resources $BUNDLE_ROOT/client_resources
+ln -s $SIMIAN_ROOT/gae_resources/icons $BUNDLE_ROOT
+ln -s $SIMIAN_ROOT/gae_resources/client_resources $BUNDLE_ROOT
 # Symlink necessary files at the root of the bundle.
 ln -s $SIMIAN_REL_PATH/mac/app.yaml $BUNDLE_ROOT/app.yaml
 ln -s $SIMIAN_REL_PATH/mac/index.yaml $BUNDLE_ROOT/index.yaml


### PR DESCRIPTION
After testing this from a fresh pool, I noticed the symlinks were bad.  I've updated and tested again to confirm this fix.  
@juofmgoblue 