### PR TITLE
Sorting tags alphabetically in drop down menu on host page

### DIFF
--- a/src/simian/mac/admin/host.py
+++ b/src/simian/mac/admin/host.py
@@ -126,7 +126,7 @@ class Host(admin.AdminHandler):
       for tag in models.Tag.GetAllTagNames():
         if tag not in tags:
           tags[tag] = False
-      tags = json.dumps(tags)
+      tags = json.dumps(tags, sort_keys=True)
 
       admin.AddTimezoneToComputerDatetimes(computer)
       computer.connection_dates.reverse()


### PR DESCRIPTION
Not sure why tags on the host page hasn't been sorted before, performance issues? It works well for us though with 30 tags at the moment.