### PR TITLE
include preinstall script closes issue #18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,6 +179,7 @@ ${SIMIAN}.dmg: os_check ${SDIST} clean_contents contents.tar.gz m2crypto vep
 	-R tlslite-*.egg \
 	-r ${SDIST} \
 	-s postflight \
+	-s preinstall \
 	-s roots.pem
 
 ${SIMIAN}.pkg: os_check ${SDIST} clean_contents contents.tar.gz m2crypto vep
@@ -207,6 +208,7 @@ ${SIMIAN}.pkg: os_check ${SDIST} clean_contents contents.tar.gz m2crypto vep
 	-R tlslite-*.egg \
 	-r ${SDIST} \
 	-s postflight \
+	-s preinstall \
 	-s roots.pem
 
 ${SIMIAN}-and-${MUNKI}.pkg: os_check ${SDIST} clean_contents m2crypto add_munkicontents contents.tar.gz vep
@@ -235,6 +237,7 @@ ${SIMIAN}-and-${MUNKI}.pkg: os_check ${SDIST} clean_contents m2crypto add_munkic
 	-R tlslite-*.egg \
 	-r ${SDIST} \
 	-s postflight \
+	-s preinstall \
 	-s roots.pem
 
 ${SIMIAN}-and-${MUNKI}.dmg: os_check ${SDIST} clean_contents m2crypto add_munkicontents contents.tar.gz vep
@@ -261,6 +264,7 @@ ${SIMIAN}-and-${MUNKI}.dmg: os_check ${SDIST} clean_contents m2crypto add_munkic
 	-R tlslite-*.egg \
 	-r ${SDIST} \
 	-s postflight \
+	-s preinstall \
 	-s roots.pem
 
 simian-pkg: ${SIMIAN}.pkg

--- a/preinstall
+++ b/preinstall
@@ -1,24 +1,10 @@
 #!/bin/bash
-simian_files=("/etc/simian/" "/usr/local/munki" "/Library/Managed Installs" "/Applications/Managed Software Center.app" "/private/var/root/Library/Preferences/ByHost/ManagedInstalls*")
+simian_files=("/Applications/Managed Software Center.app")
 
-for file in "${simian_files[@]}";
-do
-if [ -e "$file" ]
-then
-echo "Attempting to remove " "$file"
+for file in "${simian_files[@]}"; do
+
+if [ -e "$file" ]; then
 rm -rf "$file"
-
 fi
-done
 
-for plist in $(sudo pkgutil --pkgs | grep munki);
-do
-$(sudo pkgutil --forget "$plist")
 done
-
-for plist in $(sudo pkgutil --pkgs | grep simian);
-do
-$(sudo pkgutil --forget "$plist")
-done
-
-exit 0

--- a/preinstall
+++ b/preinstall
@@ -1,0 +1,24 @@
+#!/bin/bash
+simian_files=("/etc/simian/" "/usr/local/munki" "/Library/Managed Installs" "/Applications/Managed Software Center.app" "/private/var/root/Library/Preferences/ByHost/ManagedInstalls*")
+
+for file in "${simian_files[@]}";
+do
+if [ -e "$file" ]
+then
+echo "Attempting to remove " "$file"
+rm -rf "$file"
+
+fi
+done
+
+for plist in $(sudo pkgutil --pkgs | grep munki);
+do
+$(sudo pkgutil --forget "$plist")
+done
+
+for plist in $(sudo pkgutil --pkgs | grep simian);
+do
+$(sudo pkgutil --forget "$plist")
+done
+
+exit 0


### PR DESCRIPTION
This preinstall will remove simian and munki before attempting a fresh install.  

If preferred, I can limit the script to only remove managed software center.app 
(a complete uninstall seemed cleaner, but perhaps overly aggressive)