### PR TITLE
Fix executable permissions check in postinstall

### DIFF
--- a/postinstall
+++ b/postinstall
@@ -54,7 +54,7 @@ echo postflight BEGIN
 ### find & test python
 
 [[ ! -z "$PYTHON_VERSION" ]] || die "No python version specified in pkg"
-[[ ! -x "$PYTHON" ]] || die "Python is not executable"
+[[ -x "$PYTHON" ]] || die "Python is not executable"
 
 ### create temp work directory
 


### PR DESCRIPTION
On 10.12 the package install seems to fail. The install log contains this:
```
+ echo postflight BEGIN
postflight BEGIN
+ [[ ! -z 2.7 ]]
+ [[ ! -x /usr/bin/python2.7 ]]
+ die 'Python is not executable'
+ echo ERROR 'Python is not executable'
ERROR Python is not executable
+ exit 1
```

However, /usr/bin/python2.7 does have execute permissions:
```
$ ls -la /usr/bin/python2.7
lrwxr-xr-x  1 root  wheel  75 20 Sep 23:04 /usr/bin/python2.7 -> ../../System/Library/Frameworks/Python.framework/Versions/2.7/bin/python2.7
```

I think this is a simple bug in the postinstall which I have fixed in the PR, however, I don't understand why this was working before.