### PR TITLE
Update create_gae_bundle.sh to fix broken symlink

### DIFF
--- a/src/simian/util/create_gae_bundle.sh
+++ b/src/simian/util/create_gae_bundle.sh
@@ -22,7 +22,7 @@ ln -s ../$SIMIAN_REL_PATH/mac $BUNDLE_ROOT/simian/mac
 ln -s ../$SIMIAN_REL_PATH/settings.py $BUNDLE_ROOT/simian/settings.py
 
 # Symlink gae_resources.
-ln -s ../$SIMIAN_ROOT/gae_resources/client_resources $BUNDLE_ROOT/client_resources
+ln -s $SIMIAN_ROOT/gae_resources/client_resources $BUNDLE_ROOT/client_resources
 
 # Symlink necessary files at the root of the bundle.
 ln -s $SIMIAN_REL_PATH/mac/app.yaml $BUNDLE_ROOT/app.yaml


### PR DESCRIPTION
Symlink for client_resources was being created with .. before the full path from / causing it to look for a root level directory starting one folder up.  Removing the ../ makes $SIMIAN_ROOT an accurate path